### PR TITLE
Fix - Misused Options Error

### DIFF
--- a/src/cli/errors/HandleErrors.ts
+++ b/src/cli/errors/HandleErrors.ts
@@ -1,6 +1,10 @@
 import chalk from 'chalk'
 
-import { NotFoundError, SyntaxError } from '../../core/errors'
+import {
+  NotFoundError,
+  SyntaxError,
+  MisusedOptionsError,
+} from '../../core/errors'
 
 export const handleErrors = (error: Error) => {
   if (error instanceof SyntaxError) {
@@ -17,6 +21,9 @@ export const handleErrors = (error: Error) => {
   } else if (error instanceof NotFoundError) {
     const notFoundError = error as NotFoundError
     console.log(chalk.red(notFoundError.message))
+  } else if (error instanceof MisusedOptionsError) {
+    const misusedOptionsError = error as MisusedOptionsError
+    console.log(chalk.red(misusedOptionsError.message))
   } else {
     console.log(chalk.red(error.message))
   }

--- a/src/cli/errors/__tests__/HandleErrors.test.ts
+++ b/src/cli/errors/__tests__/HandleErrors.test.ts
@@ -1,7 +1,11 @@
 import chalk from 'chalk'
 
 import { handleErrors } from '../HandleErrors'
-import { NotFoundError, SyntaxError } from '../../../core/errors'
+import {
+  NotFoundError,
+  SyntaxError,
+  MisusedOptionsError,
+} from '../../../core/errors'
 
 describe('HandleErrors tests', () => {
   const log = console.log
@@ -51,6 +55,22 @@ describe('HandleErrors tests', () => {
     expect(console.log).toHaveBeenNthCalledWith(
       7,
       chalk.redBright(syntaxError.received),
+    )
+  })
+
+  it('should log the MisusedOptionsError message in the terminal', () => {
+    const misusedOptionsError = new MisusedOptionsError({
+      message:
+        'The --something option cannot be used together with the --random option',
+      options: {
+        something: 'something',
+        random: 'random',
+      },
+    })
+
+    handleErrors(misusedOptionsError)
+    expect(console.log).toHaveBeenCalledWith(
+      chalk.red(misusedOptionsError.message),
     )
   })
 })

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -10,8 +10,8 @@ import {
 } from './Types'
 
 import { TextUtils } from '../../utils'
-import { NotFoundError, SyntaxError } from '../../errors'
 import { CREATE_COMMAND_DEFAULT_OPTIONS } from './Defaults'
+import { NotFoundError, SyntaxError, MisusedOptionsError } from '../../errors'
 
 export class CreateCommand {
   readonly source: string
@@ -171,7 +171,24 @@ export class CreateCommand {
       : fileContent
   }
 
+  private _throwMisusedOptionsError() {
+    const hasNameOption = !!this.options.name
+    const hasReplaceNamesOption = !!this.options.replaceNames
+    if (hasNameOption && hasReplaceNamesOption) {
+      throw new MisusedOptionsError({
+        message:
+          'The --name option cannot be used together with the --replace-names option to prevent unexpected results',
+        options: {
+          name: this.options.name,
+          replaceNames: this.options.replaceNames,
+        },
+      })
+    }
+  }
+
   public run(): CreateCommandResult[] {
+    this._throwMisusedOptionsError()
+
     const templatesFolderPath = this._getTemplatesFolderPath()
     this._throwTemplatesFolderNotFound(templatesFolderPath)
 

--- a/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
+++ b/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
@@ -3,9 +3,13 @@ import path from 'path'
 import mockFs from 'mock-fs'
 
 import { CreateCommand } from '../CreateCommand'
-import { NotFoundError, SyntaxError } from '../../../errors'
 import { CREATE_COMMAND_DEFAULT_OPTIONS } from '../Defaults'
 import { CreateCommandResult, CreateCommandOptions } from '../Types'
+import {
+  NotFoundError,
+  SyntaxError,
+  MisusedOptionsError,
+} from '../../../errors'
 
 describe('CreateCommand tests', () => {
   const testingFolder = '__testing__'
@@ -406,5 +410,14 @@ describe('CreateCommand tests', () => {
 
     const command = new CreateCommand('symLink', testingFolder)
     expect(command.run.bind(command)).toThrowError(Error)
+  })
+
+  it('should throw MisusedOptionsError if uses the name option together with the replaceNames option', () => {
+    const command = new CreateCommand('text.txt', testingFolder, {
+      name: 'file.txt',
+      replaceNames: ['text=documentation'],
+    })
+
+    expect(command.run.bind(command)).toThrowError(MisusedOptionsError)
   })
 })

--- a/src/core/errors/MisusedOptionsError.ts
+++ b/src/core/errors/MisusedOptionsError.ts
@@ -1,0 +1,18 @@
+export interface MisusedOptionsErrorOptions<T = object> {
+  message: string
+  options: T
+}
+
+export class MisusedOptionsError<T = object> extends Error {
+  readonly name: string
+  readonly message: string
+  readonly options: T
+
+  constructor(options: MisusedOptionsErrorOptions<T>) {
+    super()
+    this.name = 'MisusedOptionsError'
+    this.message = options.message
+    this.options = options.options
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/src/core/errors/__tests__/MisusedOptionsError.test.ts
+++ b/src/core/errors/__tests__/MisusedOptionsError.test.ts
@@ -1,0 +1,25 @@
+import { MisusedOptionsError } from '../MisusedOptionsError'
+
+describe('MisusedOptionsError tests', () => {
+  const message =
+    'The --something option cannot be used together with the --random option'
+
+  const options = {
+    something: 'something',
+    random: 'random',
+  }
+
+  it('should has the correct structure', () => {
+    const misusedOptionsError = new MisusedOptionsError({ message, options })
+    expect(misusedOptionsError.message).toBe(message)
+    expect(misusedOptionsError.options).toEqual(options)
+    expect(misusedOptionsError.name).toBe('MisusedOptionsError')
+  })
+
+  it('should throws the message', () => {
+    const throwMisusedOptionsError = () => {
+      throw new MisusedOptionsError({ message, options })
+    }
+    expect(throwMisusedOptionsError).toThrow(message)
+  })
+})

--- a/src/core/errors/index.ts
+++ b/src/core/errors/index.ts
@@ -1,2 +1,6 @@
 export { NotFoundError } from './NotFoundError'
 export { SyntaxError, SyntaxErrorOptions } from './SyntaxError'
+export {
+  MisusedOptionsError,
+  MisusedOptionsErrorOptions,
+} from './MisusedOptionsError'


### PR DESCRIPTION
- Throw MisusedOptionsError when use --name and --replace-names options together