### PR TITLE
Fix - Allow the Replacement of Regex Characters in the File Content

### DIFF
--- a/src/core/utils/TextUtils.ts
+++ b/src/core/utils/TextUtils.ts
@@ -1,7 +1,13 @@
+export const escapeRegex = (str: string): string => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 export const replaceTextPieces = (
   text: string,
   pieces: { [key: string]: string },
 ): string => {
-  const regex = new RegExp(Object.keys(pieces).join('|'), 'g')
+  const escapedPieces = Object.keys(pieces).map((piece) => escapeRegex(piece))
+  const pattern = escapedPieces.join('|')
+  const regex = new RegExp(pattern, 'g')
   return text.replace(regex, (matched) => pieces[matched])
 }

--- a/src/core/utils/__tests__/TextUtils.test.ts
+++ b/src/core/utils/__tests__/TextUtils.test.ts
@@ -1,7 +1,11 @@
-import { replaceTextPieces } from '../TextUtils'
+import { replaceTextPieces, escapeRegex } from '../TextUtils'
 
 describe('TextUtils tests', () => {
   const text = 'The first episode was awesome'
+  const regexChars = '\\ ^ $ * + ? . ( ) | { } [ ]'
+
+  const escapedRegexChars =
+    '\\\\ \\^ \\$ \\* \\+ \\? \\. \\( \\) \\| \\{ \\} \\[ \\]'
 
   it('should replace multiple parts of a given text', () => {
     const partsToReplace = {
@@ -13,5 +17,21 @@ describe('TextUtils tests', () => {
     expect(replaceTextPieces(text, partsToReplace)).toBe(
       'The second movie was very bad',
     )
+  })
+
+  it('should be able to use regex reserved chars to replace text parts', () => {
+    const regexCharsArray = regexChars.split(' ')
+    const partsToReplace = {}
+
+    regexCharsArray.forEach((charToEscape) => {
+      partsToReplace[charToEscape] = '_'
+    })
+
+    const replacedChars = regexCharsArray.map(() => '_').join(' ')
+    expect(replaceTextPieces(regexChars, partsToReplace)).toBe(replacedChars)
+  })
+
+  it('should escape all regex reserved characters', () => {
+    expect(escapeRegex(regexChars)).toBe(escapedRegexChars)
   })
 })


### PR DESCRIPTION
- Escape regex to allow reserved regex characters in the --replace-content option
- Add tests to check if it is possible to replace reserved regex characters in folder and file names

P.S. All unnecessary checks were removed from the create command tests