### PR TITLE
Fix - Custom Errors Data

### DIFF
--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -81,15 +81,17 @@ export class CreateCommand {
   private _throwNamesToReplaceIncorrectlyFormatted(
     parsedNamesToReplace: ParsedNamesToReplace[] | undefined,
   ) {
-    const isReplaceNamesOptionIncorrectly = parsedNamesToReplace
-      ? parsedNamesToReplace.some(({ key, name }) => !key || !name)
-      : false
+    if (!parsedNamesToReplace || !this.options.replaceNames) return
+
+    const isReplaceNamesOptionIncorrectly = parsedNamesToReplace.some(
+      ({ key, name }) => !key || !name,
+    )
 
     if (isReplaceNamesOptionIncorrectly) {
       throw new SyntaxError({
         message: 'The --replace-names (-rn) option is incorrectly formatted',
         expected: 'key1=name1 key2=name2',
-        received: `${this.options.replaceNames?.join(' ')}`,
+        received: this.options.replaceNames.join(' '),
       })
     }
   }
@@ -110,11 +112,11 @@ export class CreateCommand {
       replaceContentObject,
     ).some(([key, text]) => !key || !text)
 
-    if (isReplaceContentOptionIncorrectly) {
+    if (this.options.replaceContent && isReplaceContentOptionIncorrectly) {
       throw new SyntaxError({
         message: 'The --replace-content (-rc) option is incorrectly formatted',
         expected: 'key1=text1 key2=text2',
-        received: `${this.options.replaceContent?.join(' ')}`,
+        received: this.options.replaceContent.join(' '),
       })
     }
   }

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -89,7 +89,7 @@ export class CreateCommand {
       throw new SyntaxError({
         message: 'The --replace-names (-rn) option is incorrectly formatted',
         expected: 'key1=name1 key2=name2',
-        received: `${this.options.replaceNames}`,
+        received: `${this.options.replaceNames?.join(' ')}`,
       })
     }
   }
@@ -114,7 +114,7 @@ export class CreateCommand {
       throw new SyntaxError({
         message: 'The --replace-content (-rc) option is incorrectly formatted',
         expected: 'key1=text1 key2=text2',
-        received: `${this.options.replaceContent}`,
+        received: `${this.options.replaceContent?.join(' ')}`,
       })
     }
   }

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -183,7 +183,7 @@ export class CreateCommand {
     if (hasNameOption && hasReplaceNamesOption) {
       throw new MisusedOptionsError({
         message:
-          'The --name option cannot be used together with the --replace-names option to prevent unexpected results',
+          'The --name (-n) option cannot be used together with the --replace-names (-rn) option to prevent unexpected results',
         options: {
           name: this.options.name,
           replaceNames: this.options.replaceNames,

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -72,7 +72,7 @@ export class CreateCommand {
   }
 
   private _getParsedNamesToReplace(): ParsedNamesToReplace[] | undefined {
-    return this.options.replaceNames?.map((keyAndName) => {
+    return this.options.replaceNames?.map?.((keyAndName) => {
       const [key, name] = keyAndName.split('=')
       return { key, name }
     })
@@ -98,7 +98,7 @@ export class CreateCommand {
 
   private _getReplaceContentObject(): ReplaceContentObject {
     const replaceContentObject: { [key: string]: string } = {}
-    this.options.replaceContent?.forEach((keyAndText) => {
+    this.options.replaceContent?.forEach?.((keyAndText) => {
       const [key, text] = keyAndText.split('=')
       replaceContentObject[key] = text
     })

--- a/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
+++ b/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
@@ -362,6 +362,16 @@ describe('CreateCommand tests', () => {
     ])
   })
 
+  it('should work normally when pass the --replace-names as boolean', () => {
+    const results = new CreateCommand('text.txt', testingFolder, {
+      replaceNames: true as any,
+    }).run()
+
+    expect(results).toEqual([
+      getCreateCommandResult('file', 'text.txt', 'text.txt'),
+    ])
+  })
+
   it('should replace a part of the content of a file', () => {
     const results = new CreateCommand('text.txt', testingFolder, {
       replaceContent: ['a file=not a simple text file'],
@@ -439,6 +449,16 @@ describe('CreateCommand tests', () => {
         'nested/folder/file.txt',
         'nested/folder/file.txt',
       ),
+    ])
+  })
+
+  it('should work normally when pass the --replace-content as boolean', () => {
+    const results = new CreateCommand('text.txt', testingFolder, {
+      replaceContent: true as any,
+    }).run()
+
+    expect(results).toEqual([
+      getCreateCommandResult('file', 'text.txt', 'text.txt'),
     ])
   })
 


### PR DESCRIPTION
- Fix SyntaxError received param formatting
- Add options short syntax in the MisusedOptionsError message

Extra:
- Make the create command runs normally when pass the --replace-names or the --replace-content as booleans