### PR TITLE
Fix - Replace File Content Before Changing Encoding

### DIFF
--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -171,10 +171,11 @@ export class CreateCommand {
     replaceContentObject: ReplaceContentObject,
     canReplaceContent: boolean,
   ): string {
-    const fileContent = fs.readFileSync(filePath, this.options.encoding)
-    return canReplaceContent
+    const fileContent = fs.readFileSync(filePath, 'utf-8')
+    const newFileContent = canReplaceContent
       ? TextUtils.replaceTextPieces(fileContent, replaceContentObject)
       : fileContent
+    return Buffer.from(newFileContent).toString(this.options.encoding)
   }
 
   private _throwMisusedOptionsError() {


### PR DESCRIPTION
- Use `Buffer.from` to change the encoding after changing the content
- Add tests to check if the created files have the same content than the templates