### PR TITLE
Fix - Throw Error If Already Exists On Destination Path

### DIFF
--- a/src/cli/errors/HandleErrors.ts
+++ b/src/cli/errors/HandleErrors.ts
@@ -4,6 +4,7 @@ import {
   NotFoundError,
   SyntaxError,
   MisusedOptionsError,
+  AlreadyExistsError,
 } from '../../core/errors'
 
 export const handleErrors = (error: Error) => {
@@ -21,6 +22,9 @@ export const handleErrors = (error: Error) => {
   } else if (error instanceof NotFoundError) {
     const notFoundError = error as NotFoundError
     console.log(chalk.red(notFoundError.message))
+  } else if (error instanceof AlreadyExistsError) {
+    const alreadyExistsError = error as AlreadyExistsError
+    console.log(chalk.red(alreadyExistsError.message))
   } else if (error instanceof MisusedOptionsError) {
     const misusedOptionsError = error as MisusedOptionsError
     console.log(chalk.red(misusedOptionsError.message))

--- a/src/cli/errors/__tests__/HandleErrors.test.ts
+++ b/src/cli/errors/__tests__/HandleErrors.test.ts
@@ -2,8 +2,9 @@ import chalk from 'chalk'
 
 import { handleErrors } from '../HandleErrors'
 import {
-  NotFoundError,
   SyntaxError,
+  NotFoundError,
+  AlreadyExistsError,
   MisusedOptionsError,
 } from '../../../core/errors'
 
@@ -71,6 +72,17 @@ describe('HandleErrors tests', () => {
     handleErrors(misusedOptionsError)
     expect(console.log).toHaveBeenCalledWith(
       chalk.red(misusedOptionsError.message),
+    )
+  })
+
+  it('should log the AlreadyExistsError message in the terminal', () => {
+    const alreadyExistsError = new AlreadyExistsError(
+      'this/is/the/path',
+      'Cannot create this/is/the/path because it already exists',
+    )
+    handleErrors(alreadyExistsError)
+    expect(console.log).toHaveBeenCalledWith(
+      chalk.red(alreadyExistsError.message),
     )
   })
 })

--- a/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
+++ b/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
@@ -6,8 +6,9 @@ import { CreateCommand } from '../CreateCommand'
 import { CREATE_COMMAND_DEFAULT_OPTIONS } from '../Defaults'
 import { CreateCommandResult, CreateCommandOptions } from '../Types'
 import {
-  NotFoundError,
   SyntaxError,
+  NotFoundError,
+  AlreadyExistsError,
   MisusedOptionsError,
 } from '../../../errors'
 
@@ -547,6 +548,18 @@ describe('CreateCommand tests', () => {
   it('should throw NotFoundError if do not find the source', () => {
     const command = new CreateCommand('NotExistingFile.txt', testingFolder)
     expect(command.run.bind(command)).toThrowError(NotFoundError)
+  })
+
+  it('should throw AlreadyExistsError if the file already exists', () => {
+    new CreateCommand('text.txt', testingFolder).run()
+    const otherCommand = new CreateCommand('text.txt', testingFolder)
+    expect(otherCommand.run.bind(otherCommand)).toThrowError(AlreadyExistsError)
+  })
+
+  it('should throw AlreadyExistsError if the folder already exists', () => {
+    new CreateCommand('docs', testingFolder).run()
+    const otherCommand = new CreateCommand('docs', testingFolder)
+    expect(otherCommand.run.bind(otherCommand)).toThrowError(AlreadyExistsError)
   })
 
   it('should throw SyntaxError if --replace-names is incorrectly formatted', () => {

--- a/src/core/errors/AlreadyExistsError.ts
+++ b/src/core/errors/AlreadyExistsError.ts
@@ -1,0 +1,13 @@
+export class AlreadyExistsError extends Error {
+  readonly name: string
+  readonly path: string
+  readonly message: string
+
+  constructor(path: string, message: string) {
+    super()
+    this.name = 'AlreadyExistsError'
+    this.path = path
+    this.message = message
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}

--- a/src/core/errors/__tests__/AlreadyExistsError.test.ts
+++ b/src/core/errors/__tests__/AlreadyExistsError.test.ts
@@ -1,0 +1,20 @@
+import { AlreadyExistsError } from '../AlreadyExistsError'
+
+describe('AlreadyExistsError tests', () => {
+  const path = 'path/to/the/folder'
+  const message = 'Cannot create src/text.txt because it already exists'
+
+  it('should have the correct structure', () => {
+    const alreadyExistsError = new AlreadyExistsError(path, message)
+    expect(alreadyExistsError.path).toBe(path)
+    expect(alreadyExistsError.message).toBe(message)
+    expect(alreadyExistsError.name).toBe('AlreadyExistsError')
+  })
+
+  it('should throw the message', () => {
+    const throwAlreadyExistsError = () => {
+      throw new AlreadyExistsError(path, message)
+    }
+    expect(throwAlreadyExistsError).toThrow(message)
+  })
+})

--- a/src/core/errors/index.ts
+++ b/src/core/errors/index.ts
@@ -1,4 +1,5 @@
 export { NotFoundError } from './NotFoundError'
+export { AlreadyExistsError } from './AlreadyExistsError'
 export { SyntaxError, SyntaxErrorOptions } from './SyntaxError'
 export {
   MisusedOptionsError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,18 @@
 export {
-  CREATE_COMMAND_DEFAULT_OPTIONS,
+  ResultTypes,
   CreateCommand,
-  CreateCommandOptions,
-  CreateCommandOptionsWithDefaults,
   CreateCommandResult,
   ParsedNamesToReplace,
   ReplaceContentObject,
-  ResultTypes,
+  CreateCommandOptions,
+  CREATE_COMMAND_DEFAULT_OPTIONS,
+  CreateCommandOptionsWithDefaults,
 } from './core/commands'
 
 export {
-  NotFoundError,
   SyntaxError,
+  NotFoundError,
+  AlreadyExistsError,
   SyntaxErrorOptions,
   MisusedOptionsError,
   MisusedOptionsErrorOptions,


### PR DESCRIPTION
- If a file or folder already exists on the destination path the create command should throw an error