### PR TITLE
Feature - Add Option to Change the Key-Value Separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,15 @@ Follow the steps below to learn how to use this library.
 
 Creates a file or folder based on the `<source> at <destination>`.
 
-| Option                              | Description                                                        | Example                                                |
-| ----------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------ |
-| -n, --name [name]                   | Changes the name of a file or folder.                              | cpf create text.txt src -n newName.txt                 |
-| -t, --templates-folder [path]       | Path to templates folder.                                          | cpf create text.txt src -t my-templates                |
-| -e, --encoding [encoding]           | Changes the content encoding of the read files.                    | cpf create text.txt src -e base64                      |
-| -rn, --replace-names [names...]     | Replaces the names of a file or folder.                            | cpf create [fileName].txt src -rn fileName=myFile      |
-| -nb, --no-brackets                  | Makes brackets not required when using the --replace-names option. | cpf create fileName.txt src -rn fileName=otherFile -nb |
-| -rc, --replace-content [content...] | Replaces parts of the contents of a file or files within a folder. | cpf create text.txt src -rc file=myFile                |
+| Option                                  | Description                                                                                 | Example                                                    |
+| --------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| -n, --name [name]                       | Changes the name of a file or folder.                                                       | cpf create text.txt src -n newName.txt                     |
+| -t, --templates-folder [path]           | Path to templates folder.                                                                   | cpf create text.txt src -t my-templates                    |
+| -e, --encoding [encoding]               | Changes the content encoding of the read files.                                             | cpf create text.txt src -e base64                          |
+| -rn, --replace-names [names...]         | Replaces the names of a file or folder.                                                     | cpf create [fileName].txt src -rn fileName=myFile          |
+| -nb, --no-brackets                      | Makes brackets not required when using the --replace-names option.                          | cpf create fileName.txt src -rn fileName=otherFile -nb     |
+| -rc, --replace-content [content...]     | Replaces parts of the contents of a file or files within a folder.                          | cpf create text.txt src -rc file=myFile                    |
+| -kvs, --key-value-separator [separator] | Defines a custom key-value separator for the --replace-names and --replace-content options. | cpf create [fileName].txt src -rn fileName@myFile -kvs "@" |
 
 - :large_blue_circle: `cpf help [command]`
 

--- a/src/cli/commands/CreateCommand/CreateCommand.ts
+++ b/src/cli/commands/CreateCommand/CreateCommand.ts
@@ -40,4 +40,9 @@ export const CreateCommand = new Command('create')
     'Replaces parts of the contents of a file or files within a folder',
     CREATE_COMMAND_DEFAULT_OPTIONS.replaceContent,
   )
+  .option(
+    '-kvs, --key-value-separator [separator]',
+    'Defines a custom key-value separator',
+    CREATE_COMMAND_DEFAULT_OPTIONS.keyValueSeparator,
+  )
   .action(createCommandAction)

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -78,7 +78,7 @@ export class CreateCommand {
 
   private _getParsedNamesToReplace(): ParsedNamesToReplace[] | undefined {
     return this.options.replaceNames?.map?.((keyAndName) => {
-      const [key, name] = keyAndName.split('=')
+      const [key, name] = keyAndName.split(this.options.keyValueSeparator)
       return { key, name }
     })
   }
@@ -93,9 +93,10 @@ export class CreateCommand {
     )
 
     if (isReplaceNamesOptionIncorrectly) {
+      const separator = this.options.keyValueSeparator
       throw new SyntaxError({
         message: 'The --replace-names (-rn) option is incorrectly formatted',
-        expected: 'key1=name1 key2=name2',
+        expected: `key1${separator}name1 key2${separator}name2`,
         received: this.options.replaceNames.join(' '),
       })
     }
@@ -104,7 +105,7 @@ export class CreateCommand {
   private _getReplaceContentObject(): ReplaceContentObject {
     const replaceContentObject: { [key: string]: string } = {}
     this.options.replaceContent?.forEach?.((keyAndText) => {
-      const [key, text] = keyAndText.split('=')
+      const [key, text] = keyAndText.split(this.options.keyValueSeparator)
       replaceContentObject[key] = text
     })
     return replaceContentObject
@@ -118,9 +119,10 @@ export class CreateCommand {
     ).some(([key, text]) => !key || !text)
 
     if (this.options.replaceContent && isReplaceContentOptionIncorrectly) {
+      const separator = this.options.keyValueSeparator
       throw new SyntaxError({
         message: 'The --replace-content (-rc) option is incorrectly formatted',
-        expected: 'key1=text1 key2=text2',
+        expected: `key1${separator}text1 key2${separator}text2`,
         received: this.options.replaceContent.join(' '),
       })
     }

--- a/src/core/commands/CreateCommand/Defaults.ts
+++ b/src/core/commands/CreateCommand/Defaults.ts
@@ -5,4 +5,5 @@ export const CREATE_COMMAND_DEFAULT_OPTIONS = {
   replaceNames: undefined,
   replaceContent: undefined,
   brackets: true,
+  keyValueSeparator: '=',
 }

--- a/src/core/commands/CreateCommand/Types.ts
+++ b/src/core/commands/CreateCommand/Types.ts
@@ -5,6 +5,7 @@ export interface CreateCommandOptions {
   replaceNames?: string[]
   replaceContent?: string[]
   brackets?: boolean
+  keyValueSeparator?: string
 }
 
 export interface CreateCommandOptionsWithDefaults extends CreateCommandOptions {
@@ -12,6 +13,7 @@ export interface CreateCommandOptionsWithDefaults extends CreateCommandOptions {
   templatesFolder: string
   encoding: BufferEncoding
   brackets: boolean
+  keyValueSeparator: string
 }
 
 export interface ParsedNamesToReplace {

--- a/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
+++ b/src/core/commands/CreateCommand/__tests__/CreateCommand.test.ts
@@ -126,6 +126,7 @@ describe('CreateCommand tests', () => {
       replaceContent: ['text=something'],
       replaceNames: ['text=NewName'],
       templatesFolder: '__custom-templates__',
+      keyValueSeparator: '@',
     }
 
     const command = new CreateCommand('text.txt', testingFolder, newOptions)
@@ -538,6 +539,22 @@ describe('CreateCommand tests', () => {
     ])
   })
 
+  it('should work with a custom key value separator', () => {
+    const results = new CreateCommand('text.txt', testingFolder, {
+      replaceNames: ['text@anything'],
+      replaceContent: ['file@complex concept'],
+      keyValueSeparator: '@',
+      brackets: false,
+    }).run()
+
+    const fileContent = readFromTestingFolder('anything.txt')
+    expect(fileContent).toBe('This is a complex concept')
+
+    expect(results).toEqual([
+      getCreateCommandResult('file', 'text.txt', 'anything.txt'),
+    ])
+  })
+
   it('should throw NotFoundError if do not find the templates folder', () => {
     const command = new CreateCommand('text.txt', testingFolder, {
       templatesFolder: 'NonExistingFolder',
@@ -587,12 +604,18 @@ describe('CreateCommand tests', () => {
       replaceNames: [''],
     })
 
+    const seventhCommand = new CreateCommand('text.txt', testingFolder, {
+      replaceNames: ['text=file'],
+      keyValueSeparator: '#',
+    })
+
     expect(firstCommand.run.bind(firstCommand)).toThrowError(SyntaxError)
     expect(secondCommand.run.bind(secondCommand)).toThrowError(SyntaxError)
     expect(thirdCommand.run.bind(thirdCommand)).toThrowError(SyntaxError)
     expect(fourthCommand.run.bind(fourthCommand)).toThrowError(SyntaxError)
     expect(fifthCommand.run.bind(fifthCommand)).toThrowError(SyntaxError)
     expect(sixthCommand.run.bind(sixthCommand)).toThrowError(SyntaxError)
+    expect(seventhCommand.run.bind(seventhCommand)).toThrowError(SyntaxError)
   })
 
   it('should throw SyntaxError if --replace-content is incorrectly formatted', () => {
@@ -620,12 +643,18 @@ describe('CreateCommand tests', () => {
       replaceContent: [''],
     })
 
+    const seventhCommand = new CreateCommand('text.txt', testingFolder, {
+      replaceContent: ['file=tutorial'],
+      keyValueSeparator: '#',
+    })
+
     expect(firstCommand.run.bind(firstCommand)).toThrowError(SyntaxError)
     expect(secondCommand.run.bind(secondCommand)).toThrowError(SyntaxError)
     expect(thirdCommand.run.bind(thirdCommand)).toThrowError(SyntaxError)
     expect(fourthCommand.run.bind(fourthCommand)).toThrowError(SyntaxError)
     expect(fifthCommand.run.bind(fifthCommand)).toThrowError(SyntaxError)
     expect(sixthCommand.run.bind(sixthCommand)).toThrowError(SyntaxError)
+    expect(seventhCommand.run.bind(seventhCommand)).toThrowError(SyntaxError)
   })
 
   it('should throw NotFoundError if the source folder is empty', () => {


### PR DESCRIPTION
P.S. This separator is used in the --replace-names and --replace-content options