### PR TITLE
Feature - Add Timestamp in File or Folder Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ console.log(results)
 - Set an alias to a file or folder inside the templates folder.
 - Config file to simplify the use of this library.
 - --silent option to run the CLI silently.
-- Add uuid or timestamp to file names.
 - Create destination folder if not exists.
 - --force option to delete existing files and folders to create the new ones.
 

--- a/src/core/commands/CreateCommand/CreateCommand.ts
+++ b/src/core/commands/CreateCommand/CreateCommand.ts
@@ -23,6 +23,7 @@ export class CreateCommand {
   private _destination: string
   private _options: CreateCommandOptionsWithDefaults
   private _createCommandResults: CreateCommandResult[]
+  private _commandStartTime: number = 0
 
   public get source() {
     return this._source
@@ -69,6 +70,10 @@ export class CreateCommand {
 
   private _clearCreateCommandResults() {
     this._createCommandResults = []
+  }
+
+  private _setCommandStartTime() {
+    this._commandStartTime = Date.now()
   }
 
   private _getTemplatesFolderPath(): string {
@@ -174,7 +179,7 @@ export class CreateCommand {
     const canAddTimestamp = name.includes(TIMESTAMP_KEY)
     if (canAddTimestamp) {
       const regex = new RegExp(TIMESTAMP_KEY, 'g')
-      return name.replace(regex, Date.now().toString())
+      return name.replace(regex, this._commandStartTime.toString())
     }
     return name
   }
@@ -330,6 +335,7 @@ export class CreateCommand {
   }
 
   public run(): CreateCommandResult[] {
+    this._setCommandStartTime()
     this._throwMisusedOptionsError()
     this._clearCreateCommandResults()
 

--- a/src/core/commands/CreateCommand/Defaults.ts
+++ b/src/core/commands/CreateCommand/Defaults.ts
@@ -7,3 +7,5 @@ export const CREATE_COMMAND_DEFAULT_OPTIONS = {
   brackets: true,
   keyValueSeparator: '=',
 }
+
+export const TIMESTAMP_KEY = '@TIME'


### PR DESCRIPTION
- Replace `@TIME` by the current timestamp in a file or folder name.
- Throw an error if you try to use the **--name (-n)** option and the file or root folder contains `@TIME` in the name

Examples:

- `file-@TIME.txt` will become `file-1234567891011.txt`
- `@TIME-@TIME.txt` will become `1234567891011-1234567891011.txt`
- A folder called `@TIME` will become `1234567891011`